### PR TITLE
deletes home property from CreateNavigator

### DIFF
--- a/navigation/CreateNavigator.js
+++ b/navigation/CreateNavigator.js
@@ -19,10 +19,6 @@ const CreateNavigator = createStackNavigator(
                 headerLeft: null,
             },
         },
-        Home: {
-            screen: HomePage
-        }
-
     },
     {
         initialRouteName: "Create",


### PR DESCRIPTION
# Navigation Bug Fix 

Deletes "Home" property from CreateNavigator file, fixing bug when going from Explore -> CreateRecipe -> Explore