### PR TITLE
Bug/image disappear on cancel

### DIFF
--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -28,8 +28,8 @@ import postImage from "./RecipeImageComponents/postImage";
 import { validateFields } from "../utils/helperFunctions/vaildateFields";
 
 //Analytics
-import { Analytics, Event} from 'expo-analytics';
-const analytics = new Analytics('UA-159002245-1');
+import { Analytics, Event } from "expo-analytics";
+const analytics = new Analytics("UA-159002245-1");
 
 function CreateRecipeForm(props) {
     const initialFormState = {
@@ -59,7 +59,8 @@ function CreateRecipeForm(props) {
     ];
 
     const postRecipe = async () => {
-        analytics.event(new Event('Recipe', 'Create recipe'))
+        analytics
+            .event(new Event("Recipe", "Create recipe"))
             .then(() => console.log("Recipe added"))
             .catch(e => console.log(e.message));
         const postRecipe = {
@@ -227,6 +228,7 @@ function CreateRecipeForm(props) {
                             <ImageUploadModal
                                 visible={imageModalVisible}
                                 setVisible={setImageModalVisible}
+                                image={image}
                                 setImage={setImage}
                             />
                             <RecipeName

--- a/components/RecipeImageComponents/ImageUploadModal.js
+++ b/components/RecipeImageComponents/ImageUploadModal.js
@@ -10,7 +10,7 @@ import { editImage } from "../../store/singleRecipe/singleRecipeActions";
 import camera from "../../assets/camera.png";
 import gallery from "../../assets/image-plus.png";
 
-function ImageUploadModal({ visible, setVisible, setImage, scope }) {
+function ImageUploadModal({ visible, setVisible, image, setImage, scope }) {
     const iconColor = "#8FCC70";
     const dispatch = useDispatch();
     const take = "take";
@@ -49,7 +49,8 @@ function ImageUploadModal({ visible, setVisible, setImage, scope }) {
         } else if (method === choose) {
             img = await ImagePicker.launchImageLibraryAsync(imgConfig);
         }
-        if (img) {
+
+        if (img && !img.cancelled) {
             if (scope && scope === "global") {
                 dispatch(editImage(img.uri));
             } else {

--- a/components/RecipeImageComponents/ImageUploadModal.js
+++ b/components/RecipeImageComponents/ImageUploadModal.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { View, TouchableOpacity, Alert, Image } from "react-native";
 import Modal from "react-native-modal";
-import { Icon } from "react-native-elements";
 import * as ImagePicker from "expo-image-picker";
 import * as Permissions from "expo-permissions";
 import styles from "../../styles/recipeImageStyles";
@@ -11,7 +10,6 @@ import camera from "../../assets/camera.png";
 import gallery from "../../assets/image-plus.png";
 
 function ImageUploadModal({ visible, setVisible, image, setImage, scope }) {
-    const iconColor = "#8FCC70";
     const dispatch = useDispatch();
     const take = "take";
     const choose = "choose"; // Pass take or choose as argument to getImage()


### PR DESCRIPTION
Previously, if you selected an image, then opened the camera or gallery _again_ but cancelled without selecting a new image, the previously selected image would disappear.
Now, the previously selected image stays in state.