### PR TITLE
Conditional rendering of "Notes" section on detailed recipe screen

### DIFF
--- a/components/IndividualRecipe.js
+++ b/components/IndividualRecipe.js
@@ -420,11 +420,14 @@ function IndividualRecipe(props) {
                                             <View
                                                 style={{ paddingRight: "80%" }}
                                             >
-                                                <Text style={styles.notes}>
-                                                    NOTES
-                                                </Text>
+                                                {recipe.notes[0].id !==
+                                                    null && (
+                                                    <Text style={styles.notes}>
+                                                        NOTES
+                                                    </Text>
+                                                )}
                                             </View>
-                                            {recipe.notes.length &&
+                                            {recipe.notes[0].id !== null &&
                                                 recipe.notes.map((note, i) => (
                                                     <IndividualRecipeNotes
                                                         key={i}
@@ -593,9 +596,15 @@ function IndividualRecipe(props) {
                                                 ),
                                             )}
 
-                                        <Text style={styles.notes}>Notes</Text>
-                                        <View style={styles.redBorder} />
-                                        {recipe.notes.length &&
+                                        {recipe.notes[0].id !== null && (
+                                            <Text style={styles.notes}>
+                                                Notes
+                                            </Text>
+                                        )}
+                                        {recipe.notes[0].id !== null && (
+                                            <View style={styles.redBorder} />
+                                        )}
+                                        {recipe.notes[0].id !== null &&
                                             recipe.notes.map((note, i) => (
                                                 <DisplayRecipeNotes
                                                     key={i}


### PR DESCRIPTION
The Notes header will not display in a recipe with no notes. For recipes with notes, display is unchanged.