### PR TITLE
adds collectCoverageFrom property to jest object in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,12 @@
         ],
         "moduleNameMapper": {
             "styled-components": "<rootDir>/node_modules/styled-components/native/dist/styled-components.native.cjs.js"
-        }
+        },
+        "collectCoverageFrom": [
+            "**/*.{js,jsx}",
+            "!**/node_modules/**",
+            "!**/vendor/**"
+        ]
     },
     "prettier": {
         "semi": true,


### PR DESCRIPTION
# Jest Config 

This PR adds the collectCoverageFrom property to the jest object in package.json to comply with Lambda School Labs code.