### PR TITLE
Bug/delete instruction

### DIFF
--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -217,7 +217,9 @@ function CreateRecipeForm({
                 key={i}
                 index={i}
                 removeInstruction={removeInstruction}
-                instruction={instruction.description}
+                instruction={
+                    savedRecipe ? instruction.description : instruction
+                }
                 setRecipe={setRecipe}
                 parent={savedRecipe ? editRecipe : create}
             />

--- a/components/Instruction.js
+++ b/components/Instruction.js
@@ -17,28 +17,8 @@ const Instruction = ({
 }) => {
     const dispatch = useDispatch();
     const [highlighted, setHighlighted] = useState(false);
-    const [instructionToRender, setInstructionToRender] = useState(
-        instruction || "",
-    );
-    useEffect(() => {
-        if (instruction) {
-            setInstructionToRender(instruction);
-        }
-    }, [instruction]);
-
-    useEffect(() => {
-        if (parent === "editRecipe") {
-            dispatch(
-                editInstruct(index, {
-                    description: instructionToRender,
-                    step_number: index + 1,
-                }),
-            );
-        }
-    }, [instructionToRender]);
 
     const handleChange = value => {
-        setInstructionToRender(value);
         if (parent === "create") {
             setRecipe(oldRecipe => ({
                 ...oldRecipe,
@@ -47,6 +27,13 @@ const Instruction = ({
                     else return step;
                 }),
             }));
+        } else if (parent === "editRecipe") {
+            dispatch(
+                editInstruct(index, {
+                    description: value,
+                    step_number: index + 1,
+                }),
+            );
         }
     };
 
@@ -92,7 +79,7 @@ const Instruction = ({
                         placeholder=" Add Instructions"
                         multiline
                         onChangeText={handleChange}
-                        value={instructionToRender}
+                        value={instruction}
                         onFocus={() => setHighlighted(true)}
                         onBlur={() => setHighlighted(false)}
                     />


### PR DESCRIPTION
This PR fixes the bug detailed in [this Trello card](https://trello.com/c/z1Vi9CgJ). Deleting any instruction that was not at the end of the list caused unexpected behavior in the display. Now the instructions display properly.

This PR also refactors the logic in the `Instruction` component to more closely resemble that in `RecipeName` and `Note`, and get rid of the confusing `useEffect` hooks.

**To test:** 
  1. Create a new recipe. 
  2. Add three steps in "Instructions."
  3. Delete step #2. 
  4. Check that numbering and content of fields is as expected.

  5. Edit a saved recipe.
  6. Add, edit, and delete steps in "Instructions."
  7. Check that numbering and content of fields is as expected.