### PR TITLE
changes navigation.push to navigation.navigate

### DIFF
--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -1,27 +1,25 @@
-import React from 'react';
-import { AsyncStorage, View, ActivityIndicator, StatusBar } from 'react-native';
+import React from "react";
+import { AsyncStorage, View, ActivityIndicator, StatusBar } from "react-native";
 
 function AuthLoadingScreen(props) {
-
     const _bootstrapAsync = async () => {
-        const userToken = await AsyncStorage.getItem('userToken');
-        props.navigation.navigate(userToken ? 'App' : 'Auth');
+        const userToken = await AsyncStorage.getItem("userToken");
+        props.navigation.navigate(userToken ? "App" : "Auth");
         // This will switch to the App screen or Auth screen and this loading
         // screen will be unmounted and thrown away.
-    }
+    };
 
     React.useEffect(() => {
         _bootstrapAsync();
-    },[])
-    
+    }, []);
+
     // Render any loading content that you like here
-
-      return (
+    return (
         <View>
-          <ActivityIndicator />
-          <StatusBar barStyle="default" />
+            <ActivityIndicator />
+            <StatusBar barStyle="default" />
         </View>
-      );
-    }
+    );
+}
 
-  export default AuthLoadingScreen;
+export default AuthLoadingScreen;

--- a/navigation/CreateNavigator.js
+++ b/navigation/CreateNavigator.js
@@ -1,21 +1,15 @@
 import { createStackNavigator } from "react-navigation-stack";
 import CreateRecipeForm from "../components/CreateRecipeForm";
-import HomePage from "../components/HomePage";
 import IndividualRecipes from "../components/IndividualRecipe.js";
 
 const CreateNavigator = createStackNavigator(
     {
         Create: {
             screen: CreateRecipeForm,
-            //   navigationOptions : {
-            //       title : "Create",
-            //       headerLeft: null
-            //   }
         },
         IndividualR: {
             screen: IndividualRecipes,
             navigationOptions: {
-                // title : "CookBook"
                 headerLeft: null,
             },
         },

--- a/navigation/MainNavigator.js
+++ b/navigation/MainNavigator.js
@@ -19,7 +19,7 @@ const MainNavigator = createBottomTabNavigator(
                 tabBarLabel: "Explore",
                 tabBarIcon: <Image style={styles.homeTab} source={search} />,
                 tabBarOnPress: ({ navigation }) => {
-                    navigation.push("Home");
+                    navigation.navigate("Home");
                 },
             },
         },
@@ -29,7 +29,7 @@ const MainNavigator = createBottomTabNavigator(
                 tabBarLabel: "Create",
                 tabBarIcon: <Image style={styles.createTab} source={plus} />,
                 tabBarOnPress: ({ navigation }) => {
-                    navigation.push("Create");
+                    navigation.navigate("Create");
                 },
             },
         },
@@ -39,7 +39,7 @@ const MainNavigator = createBottomTabNavigator(
                 tabBarLabel: "CookBook",
                 tabBarIcon: <Image style={styles.createTab} source={fork} />,
                 tabBarOnPress: ({ navigation }) => {
-                    navigation.push("CookBook");
+                    navigation.navigate("CookBook");
                 },
             },
         },


### PR DESCRIPTION
### Purpose

This PR fixes the buggy behavior of the navigation stack (going from tab to tab, getting strange behavior with the back button, extra screens and such). 

### Desired Behavior

Each tab should maintain its own stack. When navigating between tabs, each individual tab-stack should persist its state. For example, if you are on one of the tabs doing something (viewing a recipe, creating a recipe, etc.) and you navigate to a different tab, when you go back to the tab you were doing something on, the state you were in will still be there. 