### PR TITLE
resets recipe on post, navigates to home -> new recipe

### DIFF
--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -82,7 +82,9 @@ function CreateRecipeForm({
 
             recipeID = res.data.id;
             setIsLoading(false);
-            navigation.navigate("IndividualR", { recipe, recipeID });
+            setRecipe(initialCreateFormState);
+            navigation.navigate("Home");
+            navigation.push("IndividualR", { recipe, recipeID });
         } catch (err) {
             console.log("error from adding new recipe \n", err.response);
             if (err.response.status === 500) {


### PR DESCRIPTION
This PR fixes the behavior of CreateRecipeForm and navigation after you press "save" to create a recipe.  

### Desired Behavior 

After creating a recipe, you should be sent to the Home tab, with your newly created recipe open (back button available to go back to Home) and if you navigate back to the Create tab all fields should be empty. 