### PR TITLE
removes cookbook render on homepage when searching

### DIFF
--- a/components/HomePage.js
+++ b/components/HomePage.js
@@ -41,9 +41,15 @@ const HomePage = () => {
             <View>
                 {search && <Search setDish={setDish} dish={dish} />}
                 <ScrollView>
-                    <Text style={styles.heading}>Cookbook</Text>
-                    <HomeCookBook />
-                    <Text style={styles.heading}>Suggested Recipes</Text>
+                    {!search && (
+                        <>
+                            <Text style={styles.heading}>Cookbook</Text>
+                            <HomeCookBook />
+                            <Text style={styles.heading}>
+                                Suggested Recipes
+                            </Text>
+                        </>
+                    )}
                     <RecipeList />
                 </ScrollView>
             </View>


### PR DESCRIPTION
This PR conditionally renders the Cookbook based on the homepage search value in the store. If you are searching for a recipe, the cookbook section will not appear (on the homepage). 