### PR TITLE
Fix/edit prep cook time

### DIFF
--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -269,7 +269,13 @@ function CreateRecipeForm({
                                                       prep_time: min,
                                                   });
                                         }}
-                                        value={String(recipeToRender.prep_time)}
+                                        value={
+                                            recipeToRender.prep_time
+                                                ? String(
+                                                      recipeToRender.prep_time,
+                                                  )
+                                                : ""
+                                        }
                                         onFocus={() =>
                                             setHighlighted({ prep_time: true })
                                         }
@@ -313,7 +319,13 @@ function CreateRecipeForm({
                                                       cook_time: min,
                                                   });
                                         }}
-                                        value={String(recipeToRender.cook_time)}
+                                        value={
+                                            recipeToRender.cook_time
+                                                ? String(
+                                                      recipeToRender.cook_time,
+                                                  )
+                                                : ""
+                                        }
                                         onFocus={() =>
                                             setHighlighted({ cook_time: true })
                                         }

--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -259,7 +259,12 @@ function CreateRecipeForm({
                                         placeholder="minutes"
                                         keyboardType={"numeric"}
                                         onChangeText={min => {
-                                            if (isNaN(Number(min))) return;
+                                            if (
+                                                min !== "" &&
+                                                (isNaN(Number(min)) ||
+                                                    Number(min) === 0)
+                                            )
+                                                return;
                                             savedRecipe
                                                 ? dispatch(
                                                       actions.editPreptime(min),
@@ -309,7 +314,12 @@ function CreateRecipeForm({
                                         placeholder="minutes"
                                         keyboardType={"numeric"}
                                         onChangeText={min => {
-                                            if (isNaN(Number(min))) return;
+                                            if (
+                                                min !== "" &&
+                                                (isNaN(Number(min)) ||
+                                                    Number(min) === 0)
+                                            )
+                                                return;
                                             savedRecipe
                                                 ? dispatch(
                                                       actions.editCooktime(min),

--- a/components/IndividualRecipe.js
+++ b/components/IndividualRecipe.js
@@ -194,6 +194,10 @@ function IndividualRecipe(props) {
         }
     };
 
+    const hasTimeValue = time => {
+        return time !== null && time !== 0 && time !== "";
+    };
+
     if (isLoading) {
         return (
             <View
@@ -303,7 +307,7 @@ function IndividualRecipe(props) {
                                 }}
                             >
                                 <View style={styles.timeContainer}>
-                                    {recipe.prep_time !== null && (
+                                    {hasTimeValue(recipe.prep_time) && (
                                         <Text
                                             style={{
                                                 ...theme.REGULAR_FONT,
@@ -313,7 +317,7 @@ function IndividualRecipe(props) {
                                             Prep: {recipe.prep_time} min.
                                         </Text>
                                     )}
-                                    {recipe.cook_time !== null && (
+                                    {hasTimeValue(recipe.cook_time) && (
                                         <Text style={theme.REGULAR_FONT}>
                                             Cook: {recipe.cook_time} min.
                                         </Text>


### PR DESCRIPTION
This PR fixes `CreateRecipeForm` and `IndividualRecipe` to correctly save an empty `prep_time` or `cook_time` field.
**To test:**
1. Create a recipe _without_ a `Cook time` value.
2. Save. The saved recipe should display _only_ the Prep time.
3. Enter edit mode. The `Cook time` field should be empty. It shouldn't contain 'null', '0', or any other value.
4. Enter a value in the `Cook time` field.
5. Delete the existing `Prep time` value.
6. Save. The saved recipe should display _only_ the Cook time.