### PR TITLE
Styling/commit modal

### DIFF
--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -6,7 +6,8 @@ import {
     Text,
     TextInput,
     TouchableHighlight,
-    Button,
+    TouchableOpacity,
+    // Button,
 } from "react-native";
 //Analytics
 import { Analytics, Event } from "expo-analytics";
@@ -80,8 +81,7 @@ const CommitModal = props => {
                                     style={{
                                         fontFamily: theme.REGULAR_FONT_FAMILY,
                                         padding: 8,
-                                        marginBottom: 10,
-                                        marginTop: 16,
+                                        marginVertical: 16,
                                         minHeight: 109,
                                         width: "100%",
                                         borderRadius: 5,
@@ -94,19 +94,35 @@ const CommitModal = props => {
                                 <View
                                     style={{
                                         flexDirection: "row",
-                                        justifyContent: "space-around",
+                                        justifyContent: "center",
                                         width: "80%",
                                     }}
                                 >
-                                    <Button
-                                        title="Cancel"
+                                    <TouchableOpacity
                                         onPress={closeModalHandler}
-                                    />
-
-                                    <Button
-                                        title="OK"
+                                        style={{
+                                            ...theme.SECONDARY_BUTTON,
+                                            width: 100,
+                                            marginRight: 20,
+                                        }}
+                                    >
+                                        <Text
+                                            style={theme.SECONDARY_BUTTON_TEXT}
+                                        >
+                                            Cancel
+                                        </Text>
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
                                         onPress={saveModalHandler}
-                                    />
+                                        style={{
+                                            ...theme.PRIMARY_BUTTON,
+                                            width: 100,
+                                        }}
+                                    >
+                                        <Text style={theme.PRIMARY_BUTTON_TEXT}>
+                                            OK
+                                        </Text>
+                                    </TouchableOpacity>
                                 </View>
                             </View>
                         </KeyboardAvoidingView>

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -11,7 +11,7 @@ import {
 //Analytics
 import { Analytics, Event } from "expo-analytics";
 const analytics = new Analytics("UA-159002245-1");
-
+import theme from "../../styles/theme.style";
 const CommitModal = props => {
     const { commitModal, setCommitModal, saveButtonEditedRecipe } = props;
     const [author_comment, setAuthor_comment] = useState();
@@ -62,12 +62,14 @@ const CommitModal = props => {
                             >
                                 <Text
                                     style={{
-                                        fontSize: 16,
-                                        textAlign: "center",
+                                        textAlign: "left",
+                                        fontFamily: theme.BOLD_FONT_FAMILY,
+                                        fontSize: theme.REGULAR_FONT_SIZE,
+                                        paddingVertical: 2,
                                     }}
                                 >
-                                    Please leave a brief comment describing your
-                                    recipe changes.
+                                    What did you change on this version of the
+                                    recipe?
                                 </Text>
                                 <TextInput
                                     multiline

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -95,7 +95,7 @@ const CommitModal = props => {
                                     style={{
                                         flexDirection: "row",
                                         justifyContent: "center",
-                                        width: "80%",
+                                        width: "100%",
                                     }}
                                 >
                                     <TouchableOpacity
@@ -104,6 +104,7 @@ const CommitModal = props => {
                                             ...theme.SECONDARY_BUTTON,
                                             width: 100,
                                             marginRight: 20,
+                                            marginBottom: 0,
                                         }}
                                     >
                                         <Text
@@ -117,6 +118,7 @@ const CommitModal = props => {
                                         style={{
                                             ...theme.PRIMARY_BUTTON,
                                             width: 100,
+                                            marginBottom: 0,
                                         }}
                                     >
                                         <Text style={theme.PRIMARY_BUTTON_TEXT}>

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -7,12 +7,12 @@ import {
     TextInput,
     TouchableHighlight,
     TouchableOpacity,
-    // Button,
 } from "react-native";
 //Analytics
 import { Analytics, Event } from "expo-analytics";
 const analytics = new Analytics("UA-159002245-1");
 import theme from "../../styles/theme.style";
+import styles from "../../styles/commitModalStyles";
 const CommitModal = props => {
     const { commitModal, setCommitModal, saveButtonEditedRecipe } = props;
     const [author_comment, setAuthor_comment] = useState();
@@ -39,36 +39,10 @@ const CommitModal = props => {
         <View style={{ flexDirection: "row" }}>
             <Modal visible={commitModal.save} animationType="fade" transparent>
                 <TouchableHighlight onPress={closeModalHandler}>
-                    <View
-                        style={{
-                            height: "100%",
-                            width: "100%",
-                            backgroundColor: "rgba(30, 27, 27, 0.45)",
-                            alignItems: "center",
-                            justifyContent: "center",
-                        }}
-                    >
+                    <View style={styles.modalContainer}>
                         <KeyboardAvoidingView behavior={"position"}>
-                            <View
-                                style={{
-                                    backgroundColor:
-                                        "rgba(300, 300, 300, 0.95)",
-                                    borderRadius: 10,
-                                    paddingVertical: 16,
-                                    paddingHorizontal: 24,
-                                    justifyContent: "center",
-                                    alignItems: "center",
-                                    marginHorizontal: 59,
-                                }}
-                            >
-                                <Text
-                                    style={{
-                                        textAlign: "left",
-                                        fontFamily: theme.BOLD_FONT_FAMILY,
-                                        fontSize: theme.REGULAR_FONT_SIZE,
-                                        paddingVertical: 2,
-                                    }}
-                                >
+                            <View style={styles.modal}>
+                                <Text style={styles.text}>
                                     What did you change on this version of the
                                     recipe?
                                 </Text>
@@ -79,32 +53,16 @@ const CommitModal = props => {
                                         setAuthor_comment(text)
                                     }
                                     style={{
-                                        fontFamily: theme.REGULAR_FONT_FAMILY,
-                                        padding: 8,
-                                        marginVertical: 16,
-                                        minHeight: 109,
-                                        width: "100%",
-                                        borderRadius: 5,
-                                        borderWidth: 1,
-                                        borderColor: highlighted
-                                            ? "red"
-                                            : "black",
+                                        ...styles.textInput,
+                                        ...(highlighted && styles.highlighted),
                                     }}
                                 />
-                                <View
-                                    style={{
-                                        flexDirection: "row",
-                                        justifyContent: "center",
-                                        width: "100%",
-                                    }}
-                                >
+                                <View style={styles.buttonContainer}>
                                     <TouchableOpacity
                                         onPress={closeModalHandler}
                                         style={{
-                                            ...theme.SECONDARY_BUTTON,
-                                            width: 100,
-                                            marginRight: 20,
-                                            marginBottom: 0,
+                                            ...styles.cancelButton,
+                                            ...styles.narrowButton,
                                         }}
                                     >
                                         <Text
@@ -117,8 +75,7 @@ const CommitModal = props => {
                                         onPress={saveModalHandler}
                                         style={{
                                             ...theme.PRIMARY_BUTTON,
-                                            width: 100,
-                                            marginBottom: 0,
+                                            ...styles.narrowButton,
                                         }}
                                     >
                                         <Text style={theme.PRIMARY_BUTTON_TEXT}>

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -56,7 +56,7 @@ const CommitModal = props => {
                                     padding: 15,
                                     justifyContent: "center",
                                     alignItems: "center",
-                                    marginHorizontal: 20,
+                                    marginHorizontal: 59,
                                 }}
                             >
                                 <Text

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -53,7 +53,8 @@ const CommitModal = props => {
                                     backgroundColor:
                                         "rgba(300, 300, 300, 0.95)",
                                     borderRadius: 10,
-                                    padding: 15,
+                                    paddingVertical: 16,
+                                    paddingHorizontal: 24,
                                     justifyContent: "center",
                                     alignItems: "center",
                                     marginHorizontal: 59,

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -73,16 +73,18 @@ const CommitModal = props => {
                                 </Text>
                                 <TextInput
                                     multiline
+                                    placeholder="Notes"
                                     onChangeText={text =>
                                         setAuthor_comment(text)
                                     }
                                     style={{
+                                        fontFamily: theme.REGULAR_FONT_FAMILY,
+                                        padding: 8,
                                         marginBottom: 10,
-                                        marginTop: 20,
-                                        minHeight: 40,
-                                        maxWidth: "90%",
-                                        width: "90%",
-                                        borderRadius: 4,
+                                        marginTop: 16,
+                                        minHeight: 109,
+                                        width: "100%",
+                                        borderRadius: 5,
                                         borderWidth: 1,
                                         borderColor: highlighted
                                             ? "red"

--- a/components/EditRecipeComponents/Modal.js
+++ b/components/EditRecipeComponents/Modal.js
@@ -42,7 +42,7 @@ const CommitModal = props => {
                         style={{
                             height: "100%",
                             width: "100%",
-                            backgroundColor: "rgba(50, 50, 50, 0.4)",
+                            backgroundColor: "rgba(30, 27, 27, 0.45)",
                             alignItems: "center",
                             justifyContent: "center",
                         }}

--- a/styles/commitModalStyles.js
+++ b/styles/commitModalStyles.js
@@ -1,0 +1,55 @@
+import { StyleSheet } from "react-native";
+import theme from "../styles/theme.style";
+
+const styles = StyleSheet.create({
+    modalContainer: {
+        height: "100%",
+        width: "100%",
+        backgroundColor: "rgba(30, 27, 27, 0.45)",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    modal: {
+        backgroundColor: "rgba(300, 300, 300, 0.95)",
+        borderRadius: 10,
+        paddingVertical: 16,
+        paddingHorizontal: 24,
+        justifyContent: "center",
+        alignItems: "center",
+        marginHorizontal: 59,
+    },
+    text: {
+        textAlign: "left",
+        fontFamily: theme.BOLD_FONT_FAMILY,
+        fontSize: theme.REGULAR_FONT_SIZE,
+        paddingVertical: 2,
+    },
+    textInput: {
+        fontFamily: theme.REGULAR_FONT_FAMILY,
+        padding: 8,
+        marginVertical: 16,
+        minHeight: 109,
+        width: "100%",
+        borderRadius: 5,
+        borderWidth: 1,
+        borderColor: theme.INPUT_BORDER_COLOR,
+    },
+    highlighted: {
+        borderColor: theme.PRIMARY_COLOR,
+    },
+    buttonContainer: {
+        flexDirection: "row",
+        justifyContent: "center",
+        width: "100%",
+    },
+    narrowButton: {
+        width: 100,
+        marginBottom: 0,
+    },
+    cancelButton: {
+        ...theme.SECONDARY_BUTTON,
+        marginRight: 20,
+    },
+});
+
+module.exports = styles;


### PR DESCRIPTION
This PR styles the Commit Modal for and edited recipe.

**To test:** 
1. Edit a saved recipe.
2. Click "Save."
3. Check the modal against the design below.
![Screen Shot 2020-03-25 at 9 31 12 AM](https://user-images.githubusercontent.com/50860480/77561252-aebee400-6e7b-11ea-9097-8814d824c8d3.jpg)
 _Note:_ I added "Cancel" and "Save" buttons, because they're kind of necessary.