### PR TITLE
Testing/new cookbook tests

### DIFF
--- a/__tests__/store/cookbook/cookbookActions.test.js
+++ b/__tests__/store/cookbook/cookbookActions.test.js
@@ -87,3 +87,64 @@ describe("fetchCookbook action creator", () => {
         });
     });
 });
+
+describe("getAllCookbookRecipes action creator", () => {
+    test("dispatches START_FETCH_ALL_COOKBOOK", () => {
+        axiosWithAuth.mockImplementation(() => {
+            return {
+                get: () => ({}),
+            };
+        });
+        const dispatch = jest.fn();
+        cookbookActions.getAllCookbookRecipes()(dispatch);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: cookbookActions.START_FETCH_ALL_COOKBOOK,
+        });
+    });
+
+    test("dispatches FETCH_ALL_COOKBOOK_SUCCESS upon a successful request", async () => {
+        const dispatch = jest.fn();
+
+        const responseData = [{ title: "testCookbookTitle" }];
+        axiosWithAuth.mockImplementation(() => {
+            return {
+                get: () => ({ data: responseData }),
+            };
+        });
+
+        await cookbookActions.getAllCookbookRecipes()(dispatch);
+
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith({
+            type: cookbookActions.START_FETCH_ALL_COOKBOOK,
+        });
+        expect(dispatch).toHaveBeenCalledWith({
+            type: cookbookActions.FETCH_ALL_COOKBOOK_SUCCESS,
+            payload: responseData,
+        });
+    });
+
+    test("dispatches FETCH_ALL_COOKBOOK_FAILURE upon an unsuccessful request", async () => {
+        const dispatch = jest.fn();
+
+        const errorMessage = "testError";
+        axiosWithAuth.mockImplementation(() => {
+            return {
+                get: () => {
+                    throw errorMessage;
+                },
+            };
+        });
+
+        await cookbookActions.getAllCookbookRecipes()(dispatch);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: cookbookActions.START_FETCH_ALL_COOKBOOK,
+        });
+        expect(dispatch).toHaveBeenCalledWith({
+            type: cookbookActions.FETCH_ALL_COOKBOOK_FAILURE,
+            payload: errorMessage,
+        });
+    });
+});

--- a/__tests__/store/cookbook/cookbookReducer.test.js
+++ b/__tests__/store/cookbook/cookbookReducer.test.js
@@ -96,3 +96,76 @@ describe("Fetch Recipe actions return the correct state object", () => {
         expect(returnStore).toEqual(expectedStore);
     });
 });
+
+describe("Fetch All Cookbook actions return the correct state object", () => {
+    test("START_FETCH_ALL_COOKBOOK", () => {
+        const initStore = {
+            entireCookbook: [],
+            isLoading: false,
+            error: "testError",
+        };
+        const expectedStore = {
+            entireCookbook: [],
+            isLoading: true,
+            error: null,
+        };
+
+        const returnStore = cookbookReducer(initStore, {
+            type: cookbookTypes.START_FETCH_ALL_COOKBOOK,
+        });
+        expect(returnStore).toEqual(expectedStore);
+
+        const returnStore2 = cookbookReducer(returnStore, {
+            type: cookbookTypes.START_FETCH_ALL_COOKBOOK,
+        });
+        expect(returnStore2).toEqual(expectedStore);
+    });
+
+    test("FETCH_ALL_COOKBOOK_SUCCESS", () => {
+        const recipesTofetch = [
+            { title: "testRecipe1" },
+            { title: "testRecipe2" },
+        ];
+
+        const initStore = {
+            entireCookbook: [],
+            isLoading: false,
+            error: null,
+        };
+
+        const expectedStore = {
+            entireCookbook: recipesTofetch,
+            isLoading: false,
+            error: null,
+        };
+        const action = {
+            type: cookbookTypes.FETCH_ALL_COOKBOOK_SUCCESS,
+            payload: recipesTofetch,
+        };
+
+        const returnStore = cookbookReducer(initStore, action);
+        expect(returnStore).toEqual(expectedStore);
+    });
+
+    test("FETCH_ALL_COOKBOOK_FAILURE", () => {
+        const initStore = {
+            entireCookbook: [],
+            isLoading: true,
+            error: null,
+        };
+
+        const expectedStore = {
+            entireCookbook: [],
+            isLoading: false,
+            error: "testError",
+        };
+
+        const action = {
+            type: cookbookTypes.FETCH_ALL_COOKBOOK_FAILURE,
+            payload: "testError",
+        };
+
+        const returnStore = cookbookReducer(initStore, action);
+        expect(returnStore).toEqual(expectedStore);
+    });
+});


### PR DESCRIPTION
tiny PR that does what it says on the label.

Adds like, six new tests for the new cookbook and the associated store

They look veeeeery similar to the other tests. Probably because new cookbook logic is veeeeery similar to homepage cookbook logic.