### PR TITLE
fix/other-versions-not-displaying

### DIFF
--- a/store/singleRecipe/singleRecipeActions.js
+++ b/store/singleRecipe/singleRecipeActions.js
@@ -1,5 +1,6 @@
 import axiosWithAuth from "../../utils/axiosWithAuth";
 import { postImage } from "../../utils/helperFunctions/postImage";
+import { fetchAllVersionHistory } from "../version-control/versionControlActions";
 
 export const START_UPDATE_RECIPE = "START_UPDATE_RECIPE";
 export const UPDATE_RECIPE_SUCCESS = "UPDATE_RECIPE_SUCCESS";
@@ -72,6 +73,7 @@ export const submitEditedRecipe = author_comment => async (
         const res = await axiosCustom.put(`recipes/${newRecipe.id}`, newRecipe);
 
         dispatch({ type: SUBMIT_EDITED_RECIPE_SUCCESS, payload: res.data });
+        dispatch(fetchAllVersionHistory(newRecipe.id)); //Causes "Other versions" link to appear as soon as first edit on a recipe has been completed.
     } catch (err) {
         dispatch({ type: SUBMIT_EDITED_RECIPE_FAILURE, payload: err.response });
     }


### PR DESCRIPTION
Previously, if you opened a recipe with no other versions, edited it, then saved it, the "Other versions" link wouldn't appear right away. Only after you navigated away and returned to the recipe (causing it to reload) would "Other versions" appear. This PR fixes that.

**To test:**
1. Open a recipe with no other versions (or create a brand new one).
2. Edit the recipe.
3. Save.
4. Check that the "Other versions" link appears after the save completes. Press it and make sure both the new version and the original version appear in the list.