### PR TITLE
fix/unique-keys-cookbook

### DIFF
--- a/components/MyCookBook.js
+++ b/components/MyCookBook.js
@@ -39,12 +39,10 @@ const MyCookBook = () => {
         return (
             <View style={{ maxWidth: "90%", marginLeft: "5%" }}>
                 <ScrollView style={{ paddingBottom: "10%" }}>
-                    {categories.map((tag, i) => {
+                    {categories.map(tag => {
                         return (
-                            <>
-                                <Text key={i} style={styles.heading}>
-                                    {tag}
-                                </Text>
+                            <View key={tag}>
+                                <Text style={styles.heading}>{tag}</Text>
                                 {allCookbookRecipes
                                     .filter(recipeToFilter => {
                                         return (
@@ -52,15 +50,17 @@ const MyCookBook = () => {
                                         );
                                     })
                                     .map(filteredRecipe => {
+                                        const id = filteredRecipe.id;
+                                        const tag = filteredRecipe.tags[0].name;
                                         return (
                                             <Recipe
-                                                key={filteredRecipe.id}
+                                                key={`${id}.${tag}`}
                                                 recipe={filteredRecipe}
                                                 parent={"Cookbook"}
                                             />
                                         );
                                     })}
-                            </>
+                            </View>
                         );
                     })}
                 </ScrollView>


### PR DESCRIPTION
This PR eliminates that pesky error warning about list elements in `MyCookBook` not having unique `key` props.

**To test:**
1. Navigate to "CookBook" tab.
2. No warning from Expo? Good.
3. Edit the tags in a saved recipe.
4. Return to "CookBook." Recipes displaying properly? Still no warning? Even better.
5. Delete a recipe.
6. Return to "CookBook." Recipes displaying properly? Still no warning? _Soooo_ good.