### PR TITLE
Feature/ingredient prediction conditions

### DIFF
--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -105,11 +105,16 @@ function CreateRecipeForm({
             i >= 0 && j < 10;
             i--, j++
         ) {
-            Object.defineProperty(ingObj, i + 1, {
-                value: ingredients[i].name.toLowerCase(),
-                writable: true,
-                enumerable: true,
-            });
+            const name = ingredients[i].name
+                .replace(/\s|\n+/g, "")
+                .toLowerCase();
+            if (name) {
+                Object.defineProperty(ingObj, i + 1, {
+                    value: name,
+                    writable: true,
+                    enumerable: true,
+                });
+            }
         }
         savedRecipe
             ? dispatch(actions.addIngredient(newIng))

--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -106,7 +106,8 @@ function CreateRecipeForm({
             i--, j++
         ) {
             const name = ingredients[i].name.toLowerCase();
-            if (name.replace(/\s|\n+/g, "")) {
+            if (name.replace(/\s|\t|\n+/g, "")) {
+                // Remove spaces, tabs, and newlines. Add to ingObj if it still has content.
                 Object.defineProperty(ingObj, j + 1, {
                     value: name,
                     writable: true,

--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -105,10 +105,8 @@ function CreateRecipeForm({
             i >= 0 && j < 10;
             i--, j++
         ) {
-            const name = ingredients[i].name
-                .replace(/\s|\n+/g, "")
-                .toLowerCase();
-            if (name) {
+            const name = ingredients[i].name.toLowerCase();
+            if (name.replace(/\s|\n+/g, "")) {
                 Object.defineProperty(ingObj, i + 1, {
                     value: name,
                     writable: true,

--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -116,6 +116,7 @@ function CreateRecipeForm({
                 });
             }
         }
+        console.log(ingObj);
         savedRecipe
             ? dispatch(actions.addIngredient(newIng))
             : [
@@ -123,7 +124,8 @@ function CreateRecipeForm({
                       ...oldRecipe,
                       ingredients: [...oldRecipe.ingredients, newIng],
                   })),
-                  dispatch(fetchIngredients(ingObj)),
+                  Object.keys(ingObj).length >= 3 &&
+                      dispatch(fetchIngredients(ingObj)),
               ];
     };
 

--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -107,14 +107,13 @@ function CreateRecipeForm({
         ) {
             const name = ingredients[i].name.toLowerCase();
             if (name.replace(/\s|\n+/g, "")) {
-                Object.defineProperty(ingObj, i + 1, {
+                Object.defineProperty(ingObj, j + 1, {
                     value: name,
                     writable: true,
                     enumerable: true,
                 });
             }
         }
-        console.log(ingObj);
         savedRecipe
             ? dispatch(actions.addIngredient(newIng))
             : [


### PR DESCRIPTION
This PR adds conditions to prevent the Ingredient Prediction API from being called unless `CreateRecipeForm` has at least 3 ingredient names entered.

**To test:**
1. Create a new recipe.
2. Before entering any ingredients, press "+ Add Ingredient." An empty ingredient field should be added, but "Suggested Ingredients" should not appear.
3. Enter a few "empty" ingredient names, that is ingredient names consisting of nothing but `space`, `tab`, and `newline` characters.
4. Press "+ Add Ingredient." An empty ingredient field should be added, but "Suggested Ingredients" should not appear.
5. Begin adding non-empty ingredient names, and press "+ Add Ingredient" after entering each one. Once you have entered 3 non-empty ingredients, "Suggested Ingredients" should appear below.