### PR TITLE
fix/addition-cook-prep-time

### DIFF
--- a/components/TimeInput.js
+++ b/components/TimeInput.js
@@ -36,13 +36,13 @@ function TimeInput({
                 placeholder="minutes"
                 keyboardType={"numeric"}
                 onChangeText={min => {
-                    if (min !== "" && (isNaN(Number(min)) || Number(min) === 0))
-                        return;
+                    const minutes = Number(min);
+                    if (min !== "" && (isNaN(minutes) || minutes === 0)) return;
                     if (savedRecipe) {
                         if (type === "prep_time") {
-                            dispatch(editPreptime(min));
+                            dispatch(editPreptime(minutes));
                         } else if (type === "cook_time") {
-                            dispatch(editCooktime(min));
+                            dispatch(editCooktime(minutes));
                         }
                     } else {
                         setRecipe({


### PR DESCRIPTION
This PR fixes the addition of `Prep time` and `Cook time` when a recipe is edited.
**To test:**
1. Open a saved recipe.
2. Edit the `Prep time` or `Cook time`. Save.
3. Return to _Home_. Check the time displayed for the recipe. It should be the sum of the numerical values you entered in `Prep time` and `Cook time`, _not_ the concatenation of those values as strings.