### PR TITLE
Fix/pop individual recipe on blur

### DIFF
--- a/components/IndividualRecipe.js
+++ b/components/IndividualRecipe.js
@@ -40,7 +40,6 @@ import DisplayRecipeIngredient from "./DisplayRecipeComponents/DisplayRecipeIngr
 import DisplayRecipeInstruction from "./DisplayRecipeComponents/DisplayRecipeInstruction";
 import DisplayRecipeNotes from "./DisplayRecipeComponents/DisplayRecipeNotes";
 import DisplayTitle from "./DisplayRecipeComponents/DisplayTitle";
-import RecipeShareLogo from "./RecipeShareLogo";
 import FancySpinner from "./FancySpinner";
 
 function IndividualRecipe(props) {

--- a/components/IndividualRecipe.js
+++ b/components/IndividualRecipe.js
@@ -65,8 +65,6 @@ function IndividualRecipe(props) {
         "revisionID",
         "revisionId not passed",
     );
-    const navigationChildRoutes = props.navigation.dangerouslyGetParent().router
-        .childRouters;
 
     const loadRecipe = async () => {
         try {
@@ -187,14 +185,6 @@ function IndividualRecipe(props) {
                             dispatch(deleteRecipe(recipe.id));
                             dispatch(deleteCookbookRecipe(recipe.id));
                             dispatch(resetRecipe());
-                            props.navigation.pop();
-                            if (
-                                Object.keys(navigationChildRoutes).includes(
-                                    "Home",
-                                )
-                            )
-                                props.navigation.navigate("CookBook");
-                            else props.navigation.navigate("Home");
                             props.navigation.pop();
                         },
                     },

--- a/navigation/MainNavigator.js
+++ b/navigation/MainNavigator.js
@@ -17,6 +17,7 @@ const MainNavigator = createBottomTabNavigator(
                 tabBarLabel: "Home",
                 tabBarIcon: <Image style={styles.tab} source={home} />,
                 tabBarOnPress: ({ navigation }) => {
+                    navigation.pop();
                     navigation.navigate("Home");
                 },
             },
@@ -27,6 +28,7 @@ const MainNavigator = createBottomTabNavigator(
                 tabBarLabel: "Create",
                 tabBarIcon: <Image style={styles.tab} source={create} />,
                 tabBarOnPress: ({ navigation }) => {
+                    navigation.pop();
                     navigation.navigate("Create");
                 },
             },
@@ -37,6 +39,7 @@ const MainNavigator = createBottomTabNavigator(
                 tabBarLabel: "CookBook",
                 tabBarIcon: <Image style={styles.tab} source={cookbook} />,
                 tabBarOnPress: ({ navigation }) => {
+                    navigation.pop();
                     navigation.navigate("CookBook");
                 },
             },


### PR DESCRIPTION
This PR fixes the navigation problems we've had with `IndividualRecipe`. Now, any time you navigate to a new tab, `navigation.pop()` will be called to clear any screens currently on the navigation stack.

**To test:**
1. In the _Home_ tab, open a recipe.
2. Navigate to _CookBook_. Open a recipe.
3. Navigate back to _Home_. You should see the main _Home_ screen, not the recipe you had opened earlier.
4. Navigate to _CookBook_. You should see the main _CookBook_ screen, not the recipe you had opened earlier.
5. Repeat, but this time navigate from _Home_ / _Cookbook_ to the _Create_ tab. Again, any recipe you had opened in the previous tab should no longer be displayed when you return.