### PR TITLE
Feature/quantity length and keyboard

### DIFF
--- a/components/Ingredient.js
+++ b/components/Ingredient.js
@@ -102,7 +102,7 @@ const Ingredient = ({ recipeIng, removeIng, index, setRecipe, parent }) => {
                         textAlign: "center",
                     }}
                     placeholder="Amount"
-                    maxLength={3}
+                    maxLength={5}
                     keyboardType={"numbers-and-punctuation"}
                     onChangeText={qty =>
                         handleChange(

--- a/components/Ingredient.js
+++ b/components/Ingredient.js
@@ -107,7 +107,9 @@ const Ingredient = ({ recipeIng, removeIng, index, setRecipe, parent }) => {
                     onChangeText={qty =>
                         handleChange(
                             "quantity",
-                            isNaN(Number(qty)) ? ingredient.quantity : qty,
+                            qty.replace(/[0-9 ./,-]/g, "")
+                                ? ingredient.quantity
+                                : qty,
                         )
                     }
                     returnKeyType="done"

--- a/components/Ingredient.js
+++ b/components/Ingredient.js
@@ -103,7 +103,7 @@ const Ingredient = ({ recipeIng, removeIng, index, setRecipe, parent }) => {
                     }}
                     placeholder="Amount"
                     maxLength={3}
-                    keyboardType={"numeric"}
+                    keyboardType={"numbers-and-punctuation"}
                     onChangeText={qty =>
                         handleChange(
                             "quantity",


### PR DESCRIPTION
This PR changes the Ingredient `quantity` input to accept inputs of length `<= 5`, and which are not strictly numeric, including the following characters:

- `0–9`
- `" "`  (space)
- `.`
- `/`
- `,`
- `-`

**To test:**
1. Create a new recipe.
2. Try entering some ingredient quantities that match the criteria above, and some that don't. 