### PR TITLE
feature/send-all-ingredients-to-DS

### DIFF
--- a/components/CreateRecipeForm.js
+++ b/components/CreateRecipeForm.js
@@ -41,10 +41,10 @@ function CreateRecipeForm({
     const dispatch = useDispatch();
     const [recipe, setRecipe] = useState(initialCreateFormState);
     const recipeToRender = savedRecipe
-        ? useSelector(state => state.singleRecipe.recipe)
+        ? useSelector((state) => state.singleRecipe.recipe)
         : recipe;
     const savedRecipeTagNames =
-        savedRecipe && recipeToRender.tags.map(tag => tag.name);
+        savedRecipe && recipeToRender.tags.map((tag) => tag.name);
     const [editRecipe, create] = ["editRecipe", "create"];
     let [errors, setErrors] = useState([]);
     const [commitModal, setCommitModal] = useState({
@@ -62,7 +62,7 @@ function CreateRecipeForm({
         analytics
             .event(new Event("Recipe", "Create recipe"))
             .then(() => console.log("Recipe added"))
-            .catch(e => console.log(e.message));
+            .catch((e) => console.log(e.message));
         const preppedRecipe = await prepRecipeForPost(recipe);
 
         const errMessages = validateFields(preppedRecipe, "create");
@@ -96,29 +96,20 @@ function CreateRecipeForm({
     const addIng = () => {
         const newIng = { name: "", quantity: "", units: "" };
         const ingObj = {};
-        const ingredients = recipe.ingredients;
-        /* The Ingredient Prediction API returns an error if passed more than 10 ingredients.
-        The loop below creates an ingObj that includes (at most) the last 10 ingredients 
-        entered by the user. */
-        for (
-            let i = ingredients.length - 1, j = 0;
-            i >= 0 && j < 10;
-            i--, j++
-        ) {
-            const name = ingredients[i].name.toLowerCase();
-            if (name.replace(/\s|\t|\n+/g, "")) {
+        recipe.ingredients.forEach((ingredient, i) => {
+            if (ingredient.name.replace(/\s|\t|\n+/g, "")) {
                 // Remove spaces, tabs, and newlines. Add to ingObj if it still has content.
-                Object.defineProperty(ingObj, j + 1, {
-                    value: name,
+                Object.defineProperty(ingObj, i + 1, {
+                    value: ingredient.name.toLowerCase(),
                     writable: true,
                     enumerable: true,
                 });
             }
-        }
+        });
         savedRecipe
             ? dispatch(actions.addIngredient(newIng))
             : [
-                  setRecipe(oldRecipe => ({
+                  setRecipe((oldRecipe) => ({
                       ...oldRecipe,
                       ingredients: [...oldRecipe.ingredients, newIng],
                   })),
@@ -130,7 +121,7 @@ function CreateRecipeForm({
     const addInstruction = () => {
         savedRecipe
             ? dispatch(actions.addInstruction(""))
-            : setRecipe(oldRecipe => ({
+            : setRecipe((oldRecipe) => ({
                   ...oldRecipe,
                   instructions: [...oldRecipe.instructions, ""],
               }));
@@ -139,28 +130,28 @@ function CreateRecipeForm({
     const addNote = () => {
         savedRecipe
             ? dispatch(actions.addNote(""))
-            : setRecipe(oldRecipe => ({
+            : setRecipe((oldRecipe) => ({
                   ...oldRecipe,
                   notes: [...oldRecipe.notes, ""],
               }));
     };
 
-    const removeNote = index => {
-        setRecipe(oldRecipe => ({
+    const removeNote = (index) => {
+        setRecipe((oldRecipe) => ({
             ...oldRecipe,
             notes: oldRecipe.notes.filter((val, i) => i !== index),
         }));
     };
 
-    const removeIng = index => {
-        setRecipe(oldRecipe => ({
+    const removeIng = (index) => {
+        setRecipe((oldRecipe) => ({
             ...oldRecipe,
             ingredients: oldRecipe.ingredients.filter((val, i) => i !== index),
         }));
     };
 
-    const removeInstruction = index => {
-        setRecipe(oldRecipe => ({
+    const removeInstruction = (index) => {
+        setRecipe((oldRecipe) => ({
             ...oldRecipe,
             instructions: oldRecipe.instructions.filter(
                 (val, i) => i !== index,


### PR DESCRIPTION
This PR updates functionality to send all ingredients entered in `CreateRecipeForm` to the DS API. 

**To test:**
1. Create a new recipe.
2. Add 11 ingredient names.
3. Press "+ Add Ingredient." If you still get a list of suggestions, you're good!

**To _really_ test:**

4. Add 10 ingredient names that are all related, e.g. `butter`, `eggs`, `baking soda`, `brown sugar`, and other things that might go into a recipe for cookies or a cake.
5. Each time you press "+ Add Ingredient," check the suggestions. Do they fit with the existing ingredients?
6. After ingredient #10, switch gears and start adding 10 more ingredients related to a different kind of recipe, e.g. `beef`, `tomatoes`, `garlic`, `parsley`, and so on.
7. After ingredient #20, the Ingredient Prediction API should no longer be processing ingredients  1–10. Do your suggestions appear to be related only to the beef and tomato recipe, and not the cookie one? Great!