### PR TITLE
formatting logic now checks for data type and places a string into an array

### DIFF
--- a/store/generate/generateRecipeAction.js
+++ b/store/generate/generateRecipeAction.js
@@ -68,7 +68,10 @@ export const generateInstructions = (image) => async (dispatch) => {
   )
     .then((response) => response.text())
     .then((result) => {
-      const formattedInstructions = JSON.parse(JSON.parse(result)).instructions;
+      const formattedInstructions =
+        typeof JSON.parse(JSON.parse(result)).instructions === 'string'
+          ? [JSON.parse(JSON.parse(result)).instructions]
+          : JSON.parse(JSON.parse(result)).instructions;
       dispatch({
         type: GENERATE_INSTRUCTIONS_SUCCESS,
         payload: formattedInstructions,


### PR DESCRIPTION
Motivation: As a developer I want to ensure that the data returned from the various endpoints is in an array.

RC 3: https://www.notion.so/Web-RC-3-Labs-23-103e779c2e4949f1af4bcb9f25189e73

Features: New logic checks to see if returned instructions are a string and if so places that string into an array.